### PR TITLE
Implements pv table to keep track of principal variation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 ### VIKING (engine executable) 
-add_executable(viking main.cpp Board.cpp Move.cpp MoveGenerator.cpp MoveList.cpp Evaluation.cpp Search.cpp globals.cpp Uci.cpp Engine.cpp TTable.cpp)
+add_executable(viking main.cpp Board.cpp Move.cpp MoveGenerator.cpp MoveList.cpp Evaluation.cpp Search.cpp globals.cpp Uci.cpp Engine.cpp TTable.cpp PVTable.cpp)
 
 set (CMAKE_CXX_FLAGS "-Dprivate=public -std=c++11") # private members are public for testing
 

--- a/src/PVTable.cpp
+++ b/src/PVTable.cpp
@@ -1,0 +1,25 @@
+#ifndef PVTABLE_CPP // GUARD
+#define PVTABLE_CPP // GUARD
+
+/*
+ * Principal variation table implementation.
+ */
+
+#include "PVTable.hpp"
+
+void PVTable::add_move(unsigned ply, Move& move) {
+  pv_length = std::max(pv_length, ply + 1);
+  unsigned pv_index = (ply * (2 * MAX_DEPTH + 1 - ply)) / 2;
+  unsigned pv_next_index = pv_index + MAX_DEPTH - ply;
+  pv_table[pv_index] = move;
+  memcpy(pv_table + pv_index + 1, pv_table + pv_next_index, sizeof(Move) * pv_length);
+}
+
+void PVTable::print_pv() {
+  for (int i = 0; i < pv_length; ++i) {
+    pv_table[i].print();
+    std::cout << " ";
+  }
+}
+
+#endif // GUARD

--- a/src/PVTable.hpp
+++ b/src/PVTable.hpp
@@ -1,0 +1,21 @@
+#ifndef PVTABLE_HPP // GUARD
+#define PVTABLE_HPP // GUARD
+
+/*
+ * Principal variation table.
+ */
+
+#include "Move.hpp"
+
+class PVTable {
+public:
+  void add_move(unsigned ply, Move &move);
+  void print_pv();
+  
+private:
+  static const unsigned MAX_DEPTH = 64; // TODO: perhaps this should be a global option
+  Move pv_table[(MAX_DEPTH * MAX_DEPTH + MAX_DEPTH) / 2];
+  unsigned pv_length = 0;
+};
+
+#endif // GUARD

--- a/src/Search.hpp
+++ b/src/Search.hpp
@@ -10,6 +10,7 @@
 #include "MoveGenerator.hpp"
 #include "MoveList.hpp"
 #include "TTable.hpp"
+#include "PVTable.hpp"
 
 class Search {
 public:
@@ -46,9 +47,12 @@ public:
                                        Evaluation &eval);
   // TODO implement iterative deepening with time management
 private:
+  unsigned current_ply;
+  unsigned nodes_evaluated;
+  
   Move best_move;
   TTable t_table;
-  unsigned nodes_evaluated;
+  PVTable pv_table;
 };
 
 #endif // GUARD


### PR DESCRIPTION
Uses a triangular pv table to keep track of the principal variation. PV table is enclosed in the PVTable class in PVTable.hpp and PVTable.cpp. Interface is simple: add_move adds a move to the principal variation, print_pv prints the current principal variation. The pv line is printed as part of the uci info after each depth of iterative deepening.