### PR TITLE
Move order and bugs

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -794,14 +794,16 @@ bitboard Board::get_attacks_to_king(bitboard king_position, Color king_color) {
   Color op_color = negate_color(king_color);
   return (get_pawn_attacks(king_position, king_color) &
           get_piece_positions(PAWN, op_color)) |
-         (get_knight_attacks(king_position) &
-          get_piece_positions(KNIGHT, op_color)) |
-         (get_bishop_attacks(king_position) &
-          (get_piece_positions(BISHOP, op_color) |
-           get_piece_positions(QUEEN, op_color))) |
-         (get_rook_attacks(king_position) &
-          (get_piece_positions(ROOK, op_color) |
-           get_piece_positions(QUEEN, op_color)));
+    (get_knight_attacks(king_position) &
+     get_piece_positions(KNIGHT, op_color)) |
+    (get_bishop_attacks(king_position) &
+     (get_piece_positions(BISHOP, op_color) |
+      get_piece_positions(QUEEN, op_color))) |
+    (get_rook_attacks(king_position) &
+     (get_piece_positions(ROOK, op_color) |
+      get_piece_positions(QUEEN, op_color))) |
+    (get_king_attacks(king_position) &
+     (get_piece_positions(KING, op_color)));
 }
 
 // Sliding piece attack generation

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -9,6 +9,8 @@
 #define ENGINE_CPP // GUARD
 
 Engine::Engine() {
+  white_increment = 0;
+  black_increment = 0;
   time_divider = 50;
   time_set = false;
 }

--- a/src/Move.hpp
+++ b/src/Move.hpp
@@ -60,6 +60,10 @@ public:
   bool is_double_pawn_push();
   bool is_null();
   inline bool is_castle() { return get_flags() == 2 || get_flags() == 3; }
+  inline bool is_capture() {
+    return get_flags() == 4 || get_flags() == 5 ||
+           (get_flags() >= 12 && get_flags() <= 15);
+  }
 
   // Setters:
   inline void set_origin(bitboard origin) {

--- a/src/Search.hpp
+++ b/src/Search.hpp
@@ -9,8 +9,8 @@
 #include "Evaluation.hpp"
 #include "MoveGenerator.hpp"
 #include "MoveList.hpp"
-#include "TTable.hpp"
 #include "PVTable.hpp"
+#include "TTable.hpp"
 
 class Search {
 public:
@@ -45,11 +45,13 @@ public:
   int negamax_root_iterative_deepening(unsigned time_limit, Board &board,
                                        MoveGenerator &move_gen,
                                        Evaluation &eval);
+  int quiescence_search(int alpha, int beta, Board &board,
+                        MoveGenerator &move_gen, Evaluation &eval);
   // TODO implement iterative deepening with time management
 private:
   unsigned current_ply;
   unsigned nodes_evaluated;
-  
+
   Move best_move;
   TTable t_table;
   PVTable pv_table;

--- a/src/Search.hpp
+++ b/src/Search.hpp
@@ -55,6 +55,10 @@ private:
   Move best_move;
   TTable t_table;
   PVTable pv_table;
+
+  // Move Ordering
+  static const uint8_t victim_aggressor_values[6][6]; // victim_aggressor_values[victim][attacker]
+  void sort_moves(MoveList& moves, Move& pv_move, Move& tt_move, Board& board);
 };
 
 #endif // GUARD


### PR DESCRIPTION
Implements MVV-LVA move ordering within the Search class. There is still lots of opportunity for further move ordering and it should be moved into a dedicated class. This is just a start.

Fixes issue #3 by considering the attack squares of the opposing king when determining whether the king is in check.

Fixes time issue caused by white and black increments being uninitialized when using a time format with no increments. They are now initialized to 0.